### PR TITLE
remove port and www

### DIFF
--- a/bin/reveal
+++ b/bin/reveal
@@ -77,7 +77,7 @@ reveal() {
   {
       command git remote -v | command grep -E "$(echo ${argValues/ /|})" | command grep '@'  | command grep -o -E '@.*' | cut -c 2-
       command git remote -v | command grep -E "$(echo ${argValues/ /|})" | command grep '//' | command grep -o -E ':.*' | cut -c 4- | command grep -v 'heroku'
-  } | command grep fetch | command sed 's@:@\/@g' | command awk '{print $1}' | sed 's@.git$@@' | command xargs -I {} $open_cmd https://www.{} >/dev/null 2>&1
+  } | command grep fetch | command perl -pe 's@:\d{1,5}/@/@' | command sed 's@:@\/@g' | command awk '{print $1}' | sed 's@.git$@@' | command xargs -I {} $open_cmd https://{} >/dev/null 2>&1
 
     unset -f find_open_command_from_Operating_System
     unset -f no_git_dir_no_args


### PR DESCRIPTION
reveal fails when git remote is like `origin ssh://host:port/path (fetch)`