### PR TITLE
remove : substituion that breaks USER:PAT/URL

### DIFF
--- a/bin/reveal
+++ b/bin/reveal
@@ -71,9 +71,9 @@ reveal() {
       cut -c 19- | command awk '{print $1}' | command sed 's@.git$@@' | \
       command xargs -I {} $open_cmd https://dashboard.heroku.com/apps/{} https://{}.herokuapp.com >/dev/null 2>&1
   {
-      command git remote -v | command grep -E "$(echo ${argValues/ /|})" | command grep '@'  | command grep -o -E '@.*' | cut -c 2-
+      command git remote -v | command grep -E "$(echo ${argValues/ /|})" | command grep '@'  | command grep -o -E '@.*' | command sed 's@:@/@g' | cut -c 2-
       command git remote -v | command grep -E "$(echo ${argValues/ /|})" | command grep '//' | command grep -o -E ':.*' | cut -c 4- | command grep -v 'heroku'
-  } | command grep fetch | command perl -pe 's@:\d{1,5}/@/@' | command sed 's@:@\/@g' | command awk '{print $1}' | sed 's@.git$@@' | command xargs -I {} $open_cmd https://{} >/dev/null 2>&1
+  } | command grep fetch | command perl -pe 's@:\d{1,5}/@/@' | command awk '{print $1}' | sed 's@.git$@@' | command xargs -I {} $open_cmd https://{} >/dev/null 2>&1
 
     unset -f ___reveal__find_open_command_from_Operating_System
     unset -f ___reveal_no_git_dir_no_args


### PR DESCRIPTION
reveal is broken with git remotes such as `USER:PAT/github.com` because of substitution of `/` for `:`.

I do not remember what the original purpose of this substitution.

Tests would help.  Can use `bats` framework.